### PR TITLE
bugfix: Update project to distinguish definition file names

### DIFF
--- a/src/portfolio/policy_forge_data_generator/pfdg_definitions.py
+++ b/src/portfolio/policy_forge_data_generator/pfdg_definitions.py
@@ -7,7 +7,6 @@ policy_forge_data_schedule = ScheduleDefinition(cron_schedule='0 0 * * *', job=p
 
 policy_forge_upload_job = define_asset_job(name='upload_policy_forge_replica_data', selection='policy_forge_replica_data_upload')
 
-
 @asset
 def policy_forge_replica_data():
     generate_data()

--- a/src/portfolio/workspace.yaml
+++ b/src/portfolio/workspace.yaml
@@ -1,7 +1,7 @@
 load_from:
   - python_file:
-      relative_path: policy_forge_data_generator/definitions.py
+      relative_path: policy_forge_data_generator/pfdg_definitions.py
       working_directory: policy_forge_data_generator
   - python_file:
-      relative_path: CDC/definitions.py
+      relative_path: CDC/cdc_definitions.py
       working_directory: CDC


### PR DESCRIPTION
This is required as Dagster expects definition files to be unique across all locations