### PR TITLE
bugfix: Policyforge replica data structures

### DIFF
--- a/src/portfolio/policy_forge_data_generator/PolicyForgeDDL.sql
+++ b/src/portfolio/policy_forge_data_generator/PolicyForgeDDL.sql
@@ -1,7 +1,7 @@
 DROP TABLE IF EXISTS source.policy CASCADE;
 DROP TABLE IF EXISTS source.party CASCADE;
 DROP TABLE IF EXISTS source.transaction CASCADE;
-DROP TABLE IF EXISTS source.arty_policy_association CASCADE;
+DROP TABLE IF EXISTS source.party_policy_association CASCADE;
 DROP TABLE IF EXISTS source.address CASCADE;
 DROP TABLE IF EXISTS source.contact CASCADE;
 DROP TABLE IF EXISTS source.coverage CASCADE;
@@ -19,34 +19,35 @@ DROP TABLE IF EXISTS source.coverage_type CASCADE;
 DROP TABLE IF EXISTS source.wall_material_type CASCADE;
 
 CREATE TABLE source.party (
-   party_id INTEGER PRIMARY KEY,
+   party_id INTEGER NOT NULL,
    given_name VARCHAR(50) NOT NULL,
    surname VARCHAR(50) NOT NULL,
    role VARCHAR(20) NOT NULL,
-   modified TIMESTAMP NOT NULL
+   modified TIMESTAMP NOT NULL,
+   PRIMARY KEY (party_id, modified)
 );
 
 CREATE TABLE source.policy (
-   policy_id INTEGER PRIMARY KEY,
+   policy_id INTEGER NOT NULL,
    policy_number VARCHAR(15) NOT NULL,
    channel VARCHAR(20) NOT NULL,
    inception TIMESTAMP NOT NULL,
    brand VARCHAR(30) NOT NULL,
    line_of_business VARCHAR(20) NOT NULL,
-   modified TIMESTAMP NOT NULL
+   modified TIMESTAMP NOT NULL,
+   PRIMARY KEY (policy_id, modified)
 );
 
 CREATE TABLE source.party_policy_association (
-   party_policy_id INTEGER PRIMARY KEY,
+   party_policy_id INTEGER NOT NULL,
    policy_id INTEGER NOT NULL,
    party_id INTEGER NOT NULL,
    modified TIMESTAMP NOT NULL,
-   CONSTRAINT fk_party_policy_association_party FOREIGN KEY (party_id) REFERENCES source.party (party_id),
-   CONSTRAINT fk_party_policy_association_policy FOREIGN KEY (policy_id) REFERENCES source.policy (policy_id)
+   PRIMARY KEY (party_policy_id, modified)
 );
 
 CREATE TABLE source.transaction (
-   transaction_id INTEGER PRIMARY KEY,
+   transaction_id INTEGER NOT NULL,
    policy_id INTEGER NOT NULL,
    transaction_type_key VARCHAR(3) NOT NULL,
    transaction_state_key VARCHAR(3) NOT NULL,
@@ -54,39 +55,40 @@ CREATE TABLE source.transaction (
    effective TIMESTAMP NOT NULL,
    expiration TIMESTAMP NOT NULL,
    modified TIMESTAMP NOT NULL,
-   CONSTRAINT fk_transaction_policy FOREIGN KEY (policy_id) REFERENCES source.policy (policy_id)
+   PRIMARY KEY (transaction_id, modified)
 );
 
 CREATE TABLE source.address (
-   address_id INTEGER PRIMARY KEY,
+   address_id INTEGER NOT NULL,
    address_key VARCHAR(3) NOT NULL,
    address_line VARCHAR(100) NOT NULL,
    suburb VARCHAR(100) NOT NULL,
    postcode VARCHAR(4) NOT NULL,
    state VARCHAR(3) NOT NULL,
    country VARCHAR(2) NOT NULL,
-   modified TIMESTAMP NOT NULL
+   modified TIMESTAMP NOT NULL,
+   PRIMARY KEY (address_id, modified)
 );
 
 CREATE TABLE source.contact (
-   contact_id INTEGER PRIMARY KEY,
+   contact_id INTEGER NOT NULL,
    party_id INTEGER NOT NULL,
    address_id INTEGER NOT NULL,
    contact_preference VARCHAR(20) NOT NULL,
    modified TIMESTAMP NOT NULL,
-   CONSTRAINT fk_contact_address FOREIGN KEY (address_id) REFERENCES source.address (address_id)
+   PRIMARY KEY (contact_id, modified)
 );
 
 CREATE TABLE source.coverage (
-   coverage_id INTEGER PRIMARY KEY,
+   coverage_id INTEGER NOT NULL,
    coverage_type_key VARCHAR(3) NOT NULL,
    transaction_id INTEGER NOT NULL,
    modified TIMESTAMP NOT NULL,
-   CONSTRAINT fk_coverage_transaction FOREIGN KEY (transaction_id) REFERENCES source.transaction (transaction_id)
+   PRIMARY KEY (coverage_id, modified)
 );
 
 CREATE TABLE source.premium_detail (
-   premium_detail_id INTEGER PRIMARY KEY,
+   premium_detail_id INTEGER NOT NULL,
    transaction_id INTEGER NOT NULL,
    base_annual_premium DECIMAL(8, 2),
    gst DECIMAL(2, 2),
@@ -94,26 +96,27 @@ CREATE TABLE source.premium_detail (
    gross_annual_premium DECIMAL(8, 2),
    excess DECIMAL(6, 2),
    modified TIMESTAMP NOT NULL,
-   CONSTRAINT fk_premium_detail_transaction FOREIGN KEY (transaction_id) REFERENCES source.transaction (transaction_id)
+   PRIMARY KEY (premium_detail_id, modified)
 );
 
 CREATE TABLE source.contents (
-   contents_id INTEGER PRIMARY KEY,
+   contents_id INTEGER NOT NULL,
    coverage_id INTEGER NOT NULL,
    sum_insured DECIMAL(10, 2),
    modified TIMESTAMP NOT NULL,
-   CONSTRAINT fk_contents_coverage FOREIGN KEY (coverage_id) REFERENCES source.coverage (coverage_id)
+   PRIMARY KEY (contents_id, modified)
 );
 
 CREATE TABLE source.occupancy (
-   occupancy_id INTEGER PRIMARY KEY,
+   occupancy_id INTEGER NOT NULL,
    occupancy_type_key VARCHAR(3) NOT NULL,
    rental_amount DECIMAL(7, 2),
-   modified TIMESTAMP NOT NULL
+   modified TIMESTAMP NOT NULL,
+   PRIMARY KEY (occupancy_id, modified)
 );
 
 CREATE TABLE source.property (
-   property_id INTEGER PRIMARY KEY,
+   property_id INTEGER NOT NULL,
    coverage_id INTEGER NOT NULL,
    property_type_key VARCHAR(3) NOT NULL,
    roof_material_key VARCHAR(3) NOT NULL,
@@ -122,61 +125,60 @@ CREATE TABLE source.property (
    year_of_construction INTEGER NOT NULL,
    sum_insured DECIMAL(12, 2),
    modified TIMESTAMP NOT NULL,
-   CONSTRAINT fk_property_coverage FOREIGN KEY (coverage_id) REFERENCES source.coverage (coverage_id),
-   CONSTRAINT fk_property_occupancy FOREIGN KEY (occupancy_id) REFERENCES source.occupancy (occupancy_id)
+   PRIMARY KEY (property_id, modified)
 );
 
 CREATE TABLE source.roof_material_type (
-    type_id INTEGER PRIMARY KEY,
+    type_id INTEGER NOT NULL,
     type_key VARCHAR(3) NOT NULL,
     type_desc VARCHAR(50) NOT NULL,
     modified TIMESTAMP NOT NULL
 );
 
 CREATE TABLE source.property_occupation_type (
-    type_id INTEGER PRIMARY KEY,
+    type_id INTEGER NOT NULL,
     type_key VARCHAR(3) NOT NULL,
     type_desc VARCHAR(50) NOT NULL,
     modified TIMESTAMP NOT NULL
 );
 
 CREATE TABLE source.property_type (
-    type_id INTEGER PRIMARY KEY,
+    type_id INTEGER NOT NULL,
     type_key VARCHAR(3) NOT NULL,
     type_desc VARCHAR(50) NOT NULL,
     modified TIMESTAMP NOT NULL
 );
 
 CREATE TABLE source.address_type (
-    type_id INTEGER PRIMARY KEY,
+    type_id INTEGER NOT NULL,
     type_key VARCHAR(3) NOT NULL,
     type_desc VARCHAR(50) NOT NULL,
     modified TIMESTAMP NOT NULL
 );
 
 CREATE TABLE source.transaction_status_type (
-    type_id INTEGER PRIMARY KEY,
+    type_id INTEGER NOT NULL,
     type_key VARCHAR(3) NOT NULL,
     type_desc VARCHAR(50) NOT NULL,
     modified TIMESTAMP NOT NULL
 );
 
 CREATE TABLE source.transaction_type (
-    type_id INTEGER PRIMARY KEY,
+    type_id INTEGER NOT NULL,
     type_key VARCHAR(3) NOT NULL,
     type_desc VARCHAR(50) NOT NULL,
     modified TIMESTAMP NOT NULL
 );
 
 CREATE TABLE source.coverage_type (
-    type_id INTEGER PRIMARY KEY,
+    type_id INTEGER NOT NULL,
     type_key VARCHAR(3) NOT NULL,
     type_desc VARCHAR(50) NOT NULL,
     modified TIMESTAMP NOT NULL
 );
 
 CREATE TABLE source.wall_material_type (
-    type_id INTEGER PRIMARY KEY,
+    type_id INTEGER NOT NULL,
     type_key VARCHAR(3) NOT NULL,
     type_desc VARCHAR(50) NOT NULL,
     modified TIMESTAMP NOT NULL


### PR DESCRIPTION
The replica data structures did not support the delta process that the policy generator follows. This change relaxes foreign key constraints (which are no longer valid due to modified date not being part of the relationship, but now defining what makes a record unique across all tables in combination with the entity ID) and updates the primary key on each table to reflect how the system simulation works - which is to go back and modify a record rather than generate a new one for each event that takes place.