### PR TITLE
bugfix: incorrect ci trigger for dbt silver

### DIFF
--- a/.github/workflows/dbt-silver.yml
+++ b/.github/workflows/dbt-silver.yml
@@ -2,19 +2,12 @@ name: dbt-silver
 
 on:
   push:
-    branches:
-      - feat-dbt-silver*
-      - bugfix-dbt-silver*
-      - bug-dbt-silver*
-      - refactor-dbt-silver*
+    paths:
+      - 'src/portfolio/dbt_silver/models/clean/policy_forge/**'
+      
   pull_request:
-    base:
-      - main
-    head:
-      - feat-dbt-silver*
-      - bugfix-dbt-silver*
-      - bug-dbt-silver*
-      - refactor-dbt-silver*
+    paths:
+      - 'src/portfolio/dbt_silver/models/clean/policy_forge/**'
 
 jobs:
   dbt_ci:


### PR DESCRIPTION
Trying this by filtering specifically for paths on both push and pull requests as on a quick google seems like github actions does not support the ability to filter source branches on merge to main