### PR TITLE
refactor: Update go live date to make output data more recent

### DIFF
--- a/src/portfolio/policy_forge_data_generator/generate_policy_forge.py
+++ b/src/portfolio/policy_forge_data_generator/generate_policy_forge.py
@@ -22,7 +22,7 @@ Faker.seed(451)
 
 current_datetime = datetime.now()
 
-system_go_live_date = datetime(2006, 3, 25, 6, 0, 0)
+system_go_live_date = datetime(2022, 3, 12, 6, 0, 0)
 system_user = 1
 starting_staff_ids = [x for x in range(2, 22)]
 


### PR DESCRIPTION
This makes the data a little more realistic to work with. The date has been moved from 2006 to 2022